### PR TITLE
Improve performance of `filter_trace_frequency`

### DIFF
--- a/R/filter_trace_frequency_percentile.R
+++ b/R/filter_trace_frequency_percentile.R
@@ -4,12 +4,25 @@ filter_trace_frequency_percentile <- function(eventlog,
 								  reverse){
 	cum_sum <- NULL
 	lag_cum_sum <- NULL
+	.N <- NULL
+	absolute_frequency <- NULL
+	relative_frequency <- NULL
 
-	eventlog %>%
-		case_list() -> cases
+	if(nrow(eventlog) == 0) {
+		return(filter_case(eventlog, c(), reverse))
+	}
 
-	eventlog %>%
-		trace_coverage("trace") %>%
+	cases <- case_list(eventlog)
+	data.table::setDT(cases)
+
+	traces <- cases[, .(absolute_frequency = .N), by = .(trace)]
+	traces <- traces[order(absolute_frequency, decreasing = T),
+					 relative_frequency:=absolute_frequency/sum(absolute_frequency)]
+
+	traces %>%
+		select(trace, absolute = absolute_frequency, relative = relative_frequency) %>%
+		arrange(desc(absolute)) %>%
+		mutate(cum_sum = cumsum(relative)) %>%
 		mutate(lag_cum_sum = lag(cum_sum, default = 0)) %>%
 		filter(lag_cum_sum <= percentage) %>%
 		merge(cases) %>%

--- a/R/filter_trace_frequency_percentile.R
+++ b/R/filter_trace_frequency_percentile.R
@@ -25,7 +25,7 @@ filter_trace_frequency_percentile <- function(eventlog,
 		mutate(cum_sum = cumsum(relative)) %>%
 		mutate(lag_cum_sum = lag(cum_sum, default = 0)) %>%
 		filter(lag_cum_sum <= percentage) %>%
-		merge(cases) %>%
+		merge(cases, by = "trace") %>%
 		pull(!!case_id_(eventlog)) -> case_selection
 
 


### PR DESCRIPTION
This avoids to compute the `case_list` twice. Some duplication of code is the downside, but that could probably be refactored later.